### PR TITLE
Fix for trailing tasks with userinput

### DIFF
--- a/tasks/grunt_lock.js
+++ b/tasks/grunt_lock.js
@@ -64,6 +64,7 @@ module.exports = function(grunt) {
                 }
 
                 grunt.log.ok('Lockfile established');
+                rl.close();
                 done();
             };
 


### PR DESCRIPTION
I had some issues with this plugin and grunt-prompt.

All characters were displayed twice after keystroke.

Example:

``` javascript
…
prompt: {
    input: {
        options: {
            questions: [{
                config: 'echo.field',
                type: 'input',
                message: 'input: ',
                default: 'default'
            }]
        }
    }
}
…
```

``` bash
# with fix
 $ grunt prompt:input

Running "lockfile:buildprocess" (lockfile) task
>> Lockfile established

Running "prompt:input" (prompt) task
[?] input: abc

Done, without errors.




# without fix
 $ grunt prompt:input
11260: "started process with id 11260"

Running "lockfile:buildprocess" (lockfile) task
>> Lockfile established

Running "prompt:input" (prompt) task
[?] input: (default) aabbcc
[?] input: abc

```
